### PR TITLE
feat: Add Ownable, proper sort by timestamp

### DIFF
--- a/api/p/memeland/memeland.gno
+++ b/api/p/memeland/memeland.gno
@@ -20,9 +20,6 @@ type Post struct {
 	UpvoteTracker *avl.Tree // address > struct{}{}
 }
 
-type UpvoteSorter []*Post
-type DateSorter []*Post
-
 type Memeland struct {
 	*ownable.Ownable
 	Posts       []*Post
@@ -103,10 +100,22 @@ func (m *Memeland) GetPostsInRange(startTimestamp, endTimestamp int64, page, pag
 	switch sortBy {
 	// Sort by upvote descending
 	case "UPVOTES":
-		sort.Sort(UpvoteSorter(filteredPosts))
+		dateSorter := PostSorter{
+			posts: filteredPosts,
+			less: func(i, j int) bool {
+				return filteredPosts[i].UpvoteTracker.Size() > filteredPosts[j].UpvoteTracker.Size()
+			},
+		}
+		sort.Sort(dateSorter)
 	default:
 		// Sort by timestamp, beginning with newest
-		sort.Sort(DateSorter(filteredPosts))
+		dateSorter := PostSorter{
+			posts: filteredPosts,
+			less: func(i, j int) bool {
+				return filteredPosts[i].Timestamp.Before(filteredPosts[j].Timestamp)
+			},
+		}
+		sort.Sort(dateSorter)
 	}
 
 	// Pagination
@@ -189,16 +198,36 @@ func (m *Memeland) getPost(id string) *Post {
 	return nil
 }
 
-// Sort by newest first
-func (a DateSorter) Len() int      { return len(a) }
-func (a DateSorter) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
-func (a DateSorter) Less(i, j int) bool {
-	return a[i].Timestamp.Before(a[j].Timestamp)
+type PostSorter struct {
+	posts []*Post
+	less  func(i, j int) bool
 }
 
-// Sort by upvote count
-func (a UpvoteSorter) Len() int      { return len(a) }
-func (a UpvoteSorter) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
-func (a UpvoteSorter) Less(i, j int) bool {
-	return a[i].UpvoteTracker.Size() > a[j].UpvoteTracker.Size()
+func (p PostSorter) Len() int {
+	return len(p.posts)
 }
+
+func (p PostSorter) Swap(i, j int) {
+	p.posts[i], p.posts[j] = p.posts[j], p.posts[i]
+}
+
+func (p PostSorter) Less(i, j int) bool {
+	return p.Less(i, j)
+}
+
+//type UpvoteSorter []*Post
+//type DateSorter []*Post
+//
+//// Sort by newest first
+//func (a DateSorter) Len() int      { return len(a) }
+//func (a DateSorter) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+//func (a DateSorter) Less(i, j int) bool {
+//	return a[i].Timestamp.Before(a[j].Timestamp)
+//}
+//
+//// Sort by upvote count
+//func (a UpvoteSorter) Len() int      { return len(a) }
+//func (a UpvoteSorter) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+//func (a UpvoteSorter) Less(i, j int) bool {
+//	return a[i].UpvoteTracker.Size() > a[j].UpvoteTracker.Size()
+//}

--- a/api/p/memeland/memeland.gno
+++ b/api/p/memeland/memeland.gno
@@ -2,6 +2,7 @@ package memeland
 
 import (
 	"gno.land/p/demo/avl"
+	"gno.land/p/demo/ownable"
 	"gno.land/p/demo/seqid"
 	"sort"
 	"std"
@@ -20,15 +21,18 @@ type Post struct {
 }
 
 type Memeland struct {
+	*ownable.Ownable
 	Posts       []*Post
 	MemeCounter seqid.ID
 }
 
 type UpvoteSorter []*Post
+type DateSorter []*Post
 
 func NewMemeland() *Memeland {
 	return &Memeland{
-		Posts: make([]*Post, 0),
+		Ownable: ownable.New(),
+		Posts:   make([]*Post, 0),
 	}
 }
 
@@ -102,7 +106,7 @@ func (m *Memeland) GetPostsInRange(startTimestamp, endTimestamp int64, page, pag
 		sort.Sort(UpvoteSorter(filteredPosts))
 	default:
 		// Sort by timestamp, beginning with newest
-		filteredPosts = reversePosts(filteredPosts)
+		sort.Sort(DateSorter(filteredPosts))
 	}
 
 	// Pagination
@@ -121,6 +125,22 @@ func (m *Memeland) GetPostsInRange(startTimestamp, endTimestamp int64, page, pag
 
 	// Return JSON representation of paginated and sorted posts
 	return PostsToJSONString(filteredPosts[startIndex:endIndex])
+}
+
+func (m *Memeland) RemovePost(id string) string {
+	if err := m.CallerIsOwner(); err != nil {
+		panic(err)
+	}
+
+	posts := m.Posts
+	for i, post := range posts {
+		if post.ID == id {
+			posts = append(posts[:i], posts[i+1:]...)
+			return id
+		}
+	}
+
+	panic("post with specified id does not exist")
 }
 
 // PostsToJSONString converts a slice of Post structs into a JSON string representation.
@@ -169,13 +189,14 @@ func (m *Memeland) getPost(id string) *Post {
 	return nil
 }
 
-func reversePosts(posts []*Post) []*Post {
-	for i, j := 0, len(posts)-1; i < j; i, j = i+1, j-1 {
-		posts[i], posts[j] = posts[j], posts[i]
-	}
-	return posts
+// Sort by date
+func (a DateSorter) Len() int      { return len(a) }
+func (a DateSorter) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a DateSorter) Less(i, j int) bool {
+	return a[i].Timestamp.After(a[j].Timestamp)
 }
 
+// Sort by upvote count
 func (a UpvoteSorter) Len() int      { return len(a) }
 func (a UpvoteSorter) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
 func (a UpvoteSorter) Less(i, j int) bool {

--- a/api/p/memeland/memeland.gno
+++ b/api/p/memeland/memeland.gno
@@ -1,14 +1,15 @@
 package memeland
 
 import (
-	"gno.land/p/demo/avl"
-	"gno.land/p/demo/ownable"
-	"gno.land/p/demo/seqid"
 	"sort"
 	"std"
 	"strconv"
 	"strings"
 	"time"
+
+	"gno.land/p/demo/avl"
+	"gno.land/p/demo/ownable"
+	"gno.land/p/demo/seqid"
 )
 
 // Post - as previously defined

--- a/api/p/memeland/memeland.gno
+++ b/api/p/memeland/memeland.gno
@@ -189,11 +189,11 @@ func (m *Memeland) getPost(id string) *Post {
 	return nil
 }
 
-// Sort by date
+// Sort by newest first
 func (a DateSorter) Len() int      { return len(a) }
 func (a DateSorter) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
 func (a DateSorter) Less(i, j int) bool {
-	return a[i].Timestamp.After(a[j].Timestamp)
+	return a[i].Timestamp.Before(a[j].Timestamp)
 }
 
 // Sort by upvote count

--- a/api/p/memeland/memeland.gno
+++ b/api/p/memeland/memeland.gno
@@ -12,7 +12,6 @@ import (
 	"gno.land/p/demo/seqid"
 )
 
-// Post - as previously defined
 type Post struct {
 	ID            string
 	Data          string
@@ -21,14 +20,14 @@ type Post struct {
 	UpvoteTracker *avl.Tree // address > struct{}{}
 }
 
+type UpvoteSorter []*Post
+type DateSorter []*Post
+
 type Memeland struct {
 	*ownable.Ownable
 	Posts       []*Post
 	MemeCounter seqid.ID
 }
-
-type UpvoteSorter []*Post
-type DateSorter []*Post
 
 func NewMemeland() *Memeland {
 	return &Memeland{

--- a/api/p/memeland/memeland.gno
+++ b/api/p/memeland/memeland.gno
@@ -71,7 +71,7 @@ func (m *Memeland) Upvote(id string) string {
 	return "upvote successful"
 }
 
-// GetPostsInRange returns a JSON string of posts within the given timestamp range, supporting pagination.
+// GetPostsInRange returns a JSON string of posts within the given timestamp range, supporting pagination
 func (m *Memeland) GetPostsInRange(startTimestamp, endTimestamp int64, page, pageSize int, sortBy string) string {
 	if len(m.Posts) == 0 {
 		return "[]"
@@ -81,8 +81,14 @@ func (m *Memeland) GetPostsInRange(startTimestamp, endTimestamp int64, page, pag
 		panic("page count cannot be less than 1")
 	}
 
+	// No empty pages
 	if pageSize < 1 {
 		panic("page size cannot be less than 1")
+	}
+
+	// No pages larger than 10
+	if pageSize > 10 {
+		panic("page size cannot be larger than 10")
 	}
 
 	var filteredPosts []*Post
@@ -101,8 +107,8 @@ func (m *Memeland) GetPostsInRange(startTimestamp, endTimestamp int64, page, pag
 	// Sort by upvote descending
 	case "UPVOTES":
 		dateSorter := PostSorter{
-			posts: filteredPosts,
-			less: func(i, j int) bool {
+			Posts: filteredPosts,
+			LessF: func(i, j int) bool {
 				return filteredPosts[i].UpvoteTracker.Size() > filteredPosts[j].UpvoteTracker.Size()
 			},
 		}
@@ -110,8 +116,8 @@ func (m *Memeland) GetPostsInRange(startTimestamp, endTimestamp int64, page, pag
 	default:
 		// Sort by timestamp, beginning with newest
 		dateSorter := PostSorter{
-			posts: filteredPosts,
-			less: func(i, j int) bool {
+			Posts: filteredPosts,
+			LessF: func(i, j int) bool {
 				return filteredPosts[i].Timestamp.Before(filteredPosts[j].Timestamp)
 			},
 		}
@@ -136,6 +142,7 @@ func (m *Memeland) GetPostsInRange(startTimestamp, endTimestamp int64, page, pag
 	return PostsToJSONString(filteredPosts[startIndex:endIndex])
 }
 
+// RemovePost allows the owner to remove a post with a specific ID
 func (m *Memeland) RemovePost(id string) string {
 	if err := m.CallerIsOwner(); err != nil {
 		panic(err)
@@ -152,7 +159,7 @@ func (m *Memeland) RemovePost(id string) string {
 	panic("post with specified id does not exist")
 }
 
-// PostsToJSONString converts a slice of Post structs into a JSON string representation.
+// PostsToJSONString converts a slice of Post structs into a JSON string
 func PostsToJSONString(posts []*Post) string {
 	var sb strings.Builder
 	sb.WriteString("[")
@@ -169,6 +176,7 @@ func PostsToJSONString(posts []*Post) string {
 	return sb.String()
 }
 
+// PostToJSONString returns a Post formatted as a JSON string
 func PostToJSONString(post *Post) string {
 	var sb strings.Builder
 
@@ -198,36 +206,20 @@ func (m *Memeland) getPost(id string) *Post {
 	return nil
 }
 
+// PostSorter is a flexible sorter for the *Post slice
 type PostSorter struct {
-	posts []*Post
-	less  func(i, j int) bool
+	Posts []*Post
+	LessF func(i, j int) bool
 }
 
 func (p PostSorter) Len() int {
-	return len(p.posts)
+	return len(p.Posts)
 }
 
 func (p PostSorter) Swap(i, j int) {
-	p.posts[i], p.posts[j] = p.posts[j], p.posts[i]
+	p.Posts[i], p.Posts[j] = p.Posts[j], p.Posts[i]
 }
 
 func (p PostSorter) Less(i, j int) bool {
-	return p.Less(i, j)
+	return p.LessF(i, j)
 }
-
-//type UpvoteSorter []*Post
-//type DateSorter []*Post
-//
-//// Sort by newest first
-//func (a DateSorter) Len() int      { return len(a) }
-//func (a DateSorter) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
-//func (a DateSorter) Less(i, j int) bool {
-//	return a[i].Timestamp.Before(a[j].Timestamp)
-//}
-//
-//// Sort by upvote count
-//func (a UpvoteSorter) Len() int      { return len(a) }
-//func (a UpvoteSorter) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
-//func (a UpvoteSorter) Less(i, j int) bool {
-//	return a[i].UpvoteTracker.Size() > a[j].UpvoteTracker.Size()
-//}

--- a/api/p/memeland/memeland.gno
+++ b/api/p/memeland/memeland.gno
@@ -20,6 +20,9 @@ type Post struct {
 	UpvoteTracker *avl.Tree // address > struct{}{}
 }
 
+type UpvoteSorter []*Post
+type DateSorter []*Post
+
 type Memeland struct {
 	*ownable.Ownable
 	Posts       []*Post
@@ -100,22 +103,10 @@ func (m *Memeland) GetPostsInRange(startTimestamp, endTimestamp int64, page, pag
 	switch sortBy {
 	// Sort by upvote descending
 	case "UPVOTES":
-		dateSorter := PostSorter{
-			posts: filteredPosts,
-			less: func(i, j int) bool {
-				return filteredPosts[i].UpvoteTracker.Size() > filteredPosts[j].UpvoteTracker.Size()
-			},
-		}
-		sort.Sort(dateSorter)
+		sort.Sort(UpvoteSorter(filteredPosts))
 	default:
 		// Sort by timestamp, beginning with newest
-		dateSorter := PostSorter{
-			posts: filteredPosts,
-			less: func(i, j int) bool {
-				return filteredPosts[i].Timestamp.Before(filteredPosts[j].Timestamp)
-			},
-		}
-		sort.Sort(dateSorter)
+		sort.Sort(DateSorter(filteredPosts))
 	}
 
 	// Pagination
@@ -198,36 +189,16 @@ func (m *Memeland) getPost(id string) *Post {
 	return nil
 }
 
-type PostSorter struct {
-	posts []*Post
-	less  func(i, j int) bool
+// Sort by newest first
+func (a DateSorter) Len() int      { return len(a) }
+func (a DateSorter) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a DateSorter) Less(i, j int) bool {
+	return a[i].Timestamp.Before(a[j].Timestamp)
 }
 
-func (p PostSorter) Len() int {
-	return len(p.posts)
+// Sort by upvote count
+func (a UpvoteSorter) Len() int      { return len(a) }
+func (a UpvoteSorter) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a UpvoteSorter) Less(i, j int) bool {
+	return a[i].UpvoteTracker.Size() > a[j].UpvoteTracker.Size()
 }
-
-func (p PostSorter) Swap(i, j int) {
-	p.posts[i], p.posts[j] = p.posts[j], p.posts[i]
-}
-
-func (p PostSorter) Less(i, j int) bool {
-	return p.Less(i, j)
-}
-
-//type UpvoteSorter []*Post
-//type DateSorter []*Post
-//
-//// Sort by newest first
-//func (a DateSorter) Len() int      { return len(a) }
-//func (a DateSorter) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
-//func (a DateSorter) Less(i, j int) bool {
-//	return a[i].Timestamp.Before(a[j].Timestamp)
-//}
-//
-//// Sort by upvote count
-//func (a UpvoteSorter) Len() int      { return len(a) }
-//func (a UpvoteSorter) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
-//func (a UpvoteSorter) Less(i, j int) bool {
-//	return a[i].UpvoteTracker.Size() > a[j].UpvoteTracker.Size()
-//}

--- a/api/p/memeland/memeland_test.gno
+++ b/api/p/memeland/memeland_test.gno
@@ -22,7 +22,7 @@ func TestGetPostsInRangePagination(t *testing.T) {
 	m := NewMemeland()
 	now := time.Now()
 
-	numOfPosts := 10
+	numOfPosts := 5
 	var memeData []string
 	for i := 1; i <= numOfPosts; i++ {
 		// Prepare meme data
@@ -47,7 +47,7 @@ func TestGetPostsInRangePagination(t *testing.T) {
 		{page: 1, pageSize: numOfPosts, expectedNumOfPosts: numOfPosts},     // all posts on single page
 		{page: 12, pageSize: 1, expectedNumOfPosts: 0},                      // empty page
 		{page: 1, pageSize: numOfPosts + 1, expectedNumOfPosts: numOfPosts}, // page with fewer posts than its size
-		{page: 5, pageSize: numOfPosts / 5, expectedNumOfPosts: 2},          // evenly distribute posts per page
+		{page: 5, pageSize: numOfPosts / 5, expectedNumOfPosts: 1},          // evenly distribute posts per page
 	}
 
 	for _, tc := range testCases {
@@ -67,7 +67,7 @@ func TestGetPostsInRangeByTimestamp(t *testing.T) {
 	m := NewMemeland()
 	now := time.Now()
 
-	numOfPosts := 10
+	numOfPosts := 5
 	var memeData []string
 	for i := 1; i <= numOfPosts; i++ {
 		// Prepare meme data

--- a/api/p/memeland/memeland_test.gno
+++ b/api/p/memeland/memeland_test.gno
@@ -209,3 +209,21 @@ func TestUpvote(t *testing.T) {
 		t.Errorf("Expected upvotes to be 1 after upvoting, got %d", post.UpvoteTracker.Size())
 	}
 }
+
+func TestDelete(t *testing.T) {
+	alice := testutils.TestAddress("alice")
+	std.TestSetOrigCaller(alice)
+
+	m := NewMemeland()
+
+	// Add a post to Memeland
+	now := time.Now()
+	postID := m.PostMeme("Meme #1", now.Unix())
+
+	// Bob will try to delete meme posted by Alice
+	bob := testutils.TestAddress("bob")
+	std.TestSetOrigCaller(bob)
+
+	// should panic. How to catch panic? do we support recover?
+	m.RemovePost(postID)
+}

--- a/api/p/memeland/memeland_test.gno
+++ b/api/p/memeland/memeland_test.gno
@@ -26,7 +26,7 @@ func TestGetPostsInRangePagination(t *testing.T) {
 	var memeData []string
 	for i := 1; i <= numOfPosts; i++ {
 		// Prepare meme data
-		nextTime := now.Add(time.Duration(-i) * time.Minute)
+		nextTime := now.Add(time.Duration(i) * time.Minute)
 		data := ufmt.Sprintf("Meme #%d", i)
 		memeData = append(memeData, data)
 
@@ -34,8 +34,8 @@ func TestGetPostsInRangePagination(t *testing.T) {
 	}
 
 	// Get timestamps
-	beforeEarliest := now.Add(-time.Minute * time.Duration(numOfPosts+1)) // subtract 3 + 1 min from now
-	afterLatest := now.Add(time.Minute)                                   // add 1 min to now
+	beforeEarliest := now.Add(-1 * time.Minute)
+	afterLatest := now.Add(time.Duration(numOfPosts)*time.Minute + time.Minute)
 
 	testCases := []struct {
 		page               int
@@ -67,11 +67,11 @@ func TestGetPostsInRangeByTimestamp(t *testing.T) {
 	m := NewMemeland()
 	now := time.Now()
 
-	numOfPosts := 5
+	numOfPosts := 10
 	var memeData []string
 	for i := 1; i <= numOfPosts; i++ {
-		// Prep meme data
-		nextTime := now.Add(time.Duration(-i) * time.Minute)
+		// Prepare meme data
+		nextTime := now.Add(time.Duration(i) * time.Minute)
 		data := ufmt.Sprintf("Meme #%d", i)
 		memeData = append(memeData, data)
 
@@ -79,8 +79,8 @@ func TestGetPostsInRangeByTimestamp(t *testing.T) {
 	}
 
 	// Get timestamps
-	beforeEarliest := now.Add(-time.Minute * time.Duration(numOfPosts+1)) // subtract 3 + 1 min from now
-	afterLatest := now.Add(time.Minute)                                   // add 1 min to now
+	beforeEarliest := now.Add(-1 * time.Minute)
+	afterLatest := now.Add(time.Duration(numOfPosts)*time.Minute + time.Minute)
 
 	// Default sort is by addition order/timestamp
 	jsonStr := m.GetPostsInRange(
@@ -88,7 +88,7 @@ func TestGetPostsInRangeByTimestamp(t *testing.T) {
 		afterLatest.Unix(),    // end at latest post
 		1,                     // first page
 		numOfPosts,            // all memes on the page
-		"DATE_CREATED",        // do not sort by upvote
+		"DATE_CREATED",        // sort by newest first
 	)
 
 	if jsonStr == "" {
@@ -101,102 +101,71 @@ func TestGetPostsInRangeByTimestamp(t *testing.T) {
 		t.Errorf("Expected %d posts in the JSON string, but found %d", m.MemeCounter, postCount)
 	}
 
+	// Check if data is there
 	for _, expData := range memeData {
 		if !strings.Contains(jsonStr, expData) {
 			t.Errorf("Expected %s in the JSON string, but counld't find it", expData)
 		}
 	}
 
-	// todo add test to check order
+	// Check if ordering is correct, sort by created date
+	for i := 0; i < len(memeData)-2; i++ {
+		if strings.Index(jsonStr, memeData[i]) > strings.Index(jsonStr, memeData[i+1]) {
+			t.Errorf("Expected %s to be before %s, but was at %d, and %d", memeData[i], memeData[i+1], i, i+1)
+		}
+	}
 }
 
 func TestGetPostsInRangeByUpvote(t *testing.T) {
 	m := NewMemeland()
+	now := time.Now()
+
+	memeData1 := "Meme #1"
+	memeData2 := "Meme #2"
 
 	// Create posts at specific times for testing
-	now := time.Now()
-	oneHourAgo := now.Add(-time.Hour)
-	twoHoursAgo := now.Add(-2 * time.Hour)
-	threeHoursAgo := now.Add(-3 * time.Hour)
-
-	// Add posts at specific timestamps
-	id1 := m.PostMeme("Meme #1", oneHourAgo.Unix())
-	id2 := m.PostMeme("Meme #2", twoHoursAgo.Unix())
+	id1 := m.PostMeme(memeData1, now.Unix())
+	id2 := m.PostMeme(memeData2, now.Add(time.Minute).Unix())
 
 	m.Upvote(id1)
 	m.Upvote(id2)
 
 	// Change caller so avoid double upvote panic
 	std.TestSetOrigCaller(testutils.TestAddress("alice"))
-	m.Upvote(id2)
+	m.Upvote(id1)
 
 	// Final upvote count:
-	// Meme #1 - 1 upvote
-	// Meme #2 - 2 upvotes
+	// Meme #1 - 2 upvote
+	// Meme #2 - 1 upvotes
 
-	// Define test cases for different time ranges and pagination scenarios
-	testCases := []struct {
-		name           string
-		startTimestamp int64
-		endTimestamp   int64
-		page           int
-		pageSize       int
-		expectedCount  int
-		expectedData   []string
-	}{
-		{
-			name:           "Upvote Sorted All Posts",
-			startTimestamp: threeHoursAgo.Add(-1 * time.Minute).Unix(), // Slightly before threeHoursAgo
-			endTimestamp:   now.Unix(),
-			page:           1,
-			pageSize:       10,
-			expectedCount:  2,
-			expectedData:   []string{"Meme #1", "Meme #2"},
-		},
-		{
-			name:           "Upvote Sorted Pagination Test",
-			startTimestamp: twoHoursAgo.Add(-1 * time.Minute).Unix(),
-			endTimestamp:   now.Unix(),
-			page:           1,
-			pageSize:       1, // Only request one post per page
-			expectedCount:  1,
-			expectedData:   []string{"Meme #2"},
-		},
-		{
-			name:           "Upvote Sorted Pagination Test: Second Post",
-			startTimestamp: threeHoursAgo.Unix(),
-			endTimestamp:   now.Unix(),
-			page:           2,
-			pageSize:       1,
-			expectedCount:  1,
-			expectedData:   []string{"Meme #1"},
-		},
+	// Get timestamps
+	beforeEarliest := now.Add(-time.Minute)
+	afterLatest := now.Add(time.Hour)
+
+	// Default sort is by addition order/timestamp
+	jsonStr := m.GetPostsInRange(
+		beforeEarliest.Unix(), // start at earliest post
+		afterLatest.Unix(),    // end at latest post
+		1,                     // first page
+		2,                     // all memes on the page
+		"UPVOTE",              // sort by upvote
+	)
+
+	if jsonStr == "" {
+		t.Error("Expected non-empty JSON string, got empty string")
 	}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			// Sort by Upvote descending
-			jsonStr := m.GetPostsInRange(tc.startTimestamp, tc.endTimestamp, tc.page, tc.pageSize, "UPVOTES")
-
-			if jsonStr == "" {
-				t.Error("Expected non-empty JSON string, got empty string")
-			}
-
-			// Count the number of posts returned in the JSON string as a rudimentary check for correct pagination/filtering
-			postCount := strings.Count(jsonStr, `"id":"`)
-			if postCount != tc.expectedCount {
-				t.Errorf("Expected %d posts in the JSON string, but found %d", tc.expectedCount, postCount)
-			}
-
-			for _, expData := range tc.expectedData {
-				if !strings.Contains(jsonStr, expData) {
-					t.Errorf("Expected %s in the JSON string, but counld't find it", expData)
-				}
-			}
-
-			// todo add test to check order
-		})
+	// Count the number of posts returned in the JSON string as a rudimentary check for correct pagination/filtering
+	postCount := strings.Count(jsonStr, `"id":"`)
+	if postCount != m.MemeCounter {
+		t.Errorf("Expected %d posts in the JSON string, but found %d", m.MemeCounter, postCount)
 	}
+
+	// Check if ordering is correct
+	if strings.Index(jsonStr, "Meme #1") > strings.Index(jsonStr, "Meme #2") {
+		t.Errorf("Expected %s to be before %s", memeData1, memeData2)
+	}
+
 }
 
 func TestNoPosts(t *testing.T) {

--- a/api/p/memeland/memeland_test.gno
+++ b/api/p/memeland/memeland_test.gno
@@ -165,7 +165,6 @@ func TestGetPostsInRangeByUpvote(t *testing.T) {
 	if strings.Index(jsonStr, "Meme #1") > strings.Index(jsonStr, "Meme #2") {
 		t.Errorf("Expected %s to be before %s", memeData1, memeData2)
 	}
-
 }
 
 func TestNoPosts(t *testing.T) {
@@ -179,7 +178,6 @@ func TestNoPosts(t *testing.T) {
 	if jsonStr != "[]" {
 		t.Errorf("Expected 0 posts to return [], got %s", jsonStr)
 	}
-
 }
 
 func TestUpvote(t *testing.T) {

--- a/api/p/memeland/memeland_test.gno
+++ b/api/p/memeland/memeland_test.gno
@@ -224,6 +224,12 @@ func TestDelete(t *testing.T) {
 	bob := testutils.TestAddress("bob")
 	std.TestSetOrigCaller(bob)
 
-	// should panic. How to catch panic? do we support recover?
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("code did not panic when in should have")
+		}
+	}()
+
+	// Should panic - caught by defer
 	m.RemovePost(postID)
 }

--- a/api/r/memeland/memeland.gno
+++ b/api/r/memeland/memeland.gno
@@ -1,8 +1,9 @@
 package memeland
 
 import (
-	"gno.land/demo/p/memeland"
 	"time"
+
+	"gno.land/demo/p/memeland"
 )
 
 var m = memeland.NewMemeland()


### PR DESCRIPTION
## Description

This PR adds `Ownable` to the Memeland realm, and introduces a `RemovePost()` for handling moderation of posts.

It also introduces proper sorting by the timestamp the memes were created, as prevously it was purely based on the order of addition. 

This PR also makes all of the tests for the Memeland package better, and adds tests for newly introduced functionality.

Considerations: If we choose to deploy the realm via genesis, ownership needs to be transferred to a trusted address in the `init()` of the realm. 