### PR TITLE
feat: add r/demo/users

### DIFF
--- a/api/p/memeland/gno.mod
+++ b/api/p/memeland/gno.mod
@@ -6,4 +6,5 @@ require (
 	gno.land/p/demo/seqid v0.0.0-latest
 	gno.land/p/demo/testutils v0.0.0-latest
 	gno.land/p/demo/ufmt v0.0.0-latest
+	gno.land/r/demo/users v0.0.0-latest
 )

--- a/api/p/memeland/memeland.gno
+++ b/api/p/memeland/memeland.gno
@@ -53,7 +53,7 @@ func (m *Memeland) PostMeme(data string, timestamp int64) string {
 	// check address is register
 	author := std.PrevRealm().Addr()
 	if !isUserRegistered(author) {
-		panic("address not registered")
+		panic("address not registered. Can you go to register in r/demo/users for post after")
 	}
 
 	// Generate ID

--- a/api/p/memeland/memeland.gno
+++ b/api/p/memeland/memeland.gno
@@ -10,6 +10,7 @@ import (
 	"gno.land/p/demo/avl"
 	"gno.land/p/demo/ownable"
 	"gno.land/p/demo/seqid"
+	"gno.land/r/demo/users"
 )
 
 const (
@@ -38,10 +39,21 @@ func NewMemeland() *Memeland {
 	}
 }
 
+func isUserRegistered(add std.Address) bool {
+	user := users.GetUserByAddress(add)
+	return user != nil
+}
+
 // PostMeme - Adds a new post
 func (m *Memeland) PostMeme(data string, timestamp int64) string {
 	if data == "" || timestamp <= 0 {
 		panic("timestamp or data cannot be empty")
+	}
+
+	// check address is register
+	author := std.PrevRealm().Addr()
+	if !isUserRegistered(author) {
+		panic("address not registered")
 	}
 
 	// Generate ID
@@ -50,7 +62,7 @@ func (m *Memeland) PostMeme(data string, timestamp int64) string {
 	newPost := &Post{
 		ID:            id,
 		Data:          data,
-		Author:        std.PrevRealm().Addr(),
+		Author:        author,
 		Timestamp:     time.Unix(timestamp, 0),
 		UpvoteTracker: avl.NewTree(),
 	}

--- a/api/p/memeland/memeland.gno
+++ b/api/p/memeland/memeland.gno
@@ -53,7 +53,7 @@ func (m *Memeland) PostMeme(data string, timestamp int64) string {
 	// check address is register
 	author := std.PrevRealm().Addr()
 	if !isUserRegistered(author) {
-		panic("address not registered. Can you go to register in r/demo/users for post after")
+		panic("you have to register in r/demo/users to post!")
 	}
 
 	// Generate ID


### PR DESCRIPTION
Hi @leohhhn ,

I added `r/demo/users`  to  `p/memeland`.

I was able to test it locally, but I wanted to do it with the `Adena` version as well. However, I couldn't find a way to have my Adena public key in my `gnokey list`, and from what I found, I believe it's not possible.
I just need to do a unit test on it to be complete. If you could review it when you have time, that would be great. Thank you!

<img width="1276" alt="SCR-20240625-pkhc" src="https://github.com/gnolang/memeland/assets/90353329/e686f5d9-ceac-4819-8748-f10e9241a09c">
<img width="556" alt="SCR-20240625-pkpn" src="https://github.com/gnolang/memeland/assets/90353329/05c9705b-8226-493b-bb17-7f164b39a058">
<img width="201" alt="SCR-20240625-pksb" src="https://github.com/gnolang/memeland/assets/90353329/24ce04c4-7ff2-4aa8-9a8b-bce1ee1ad90d">
<img width="1221" alt="SCR-20240625-pleu" src="https://github.com/gnolang/memeland/assets/90353329/029b998d-0613-4cf8-8d00-d595441a797a">
